### PR TITLE
update openstack-k8s-operators to 20221105

### DIFF
--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -32,8 +32,8 @@ import (
 
 	databasev1beta1 "github.com/openstack-k8s-operators/galera-operator/api/v1beta1"
 	mariadb "github.com/openstack-k8s-operators/galera-operator/pkg"
-	common "github.com/openstack-k8s-operators/lib-common/pkg/common"
-	helper "github.com/openstack-k8s-operators/lib-common/pkg/helper"
+	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	job "github.com/openstack-k8s-operators/lib-common/modules/common/job"
 )
 
 // MariaDBDatabaseReconciler reconciles a MariaDBDatabase object
@@ -137,7 +137,7 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		dbDeleteHash := instance.Status.Hash[databasev1beta1.DbDeleteHash]
-		dbDeleteJob := common.NewJob(
+		dbDeleteJob := job.NewJob(
 			jobDef,
 			"deleteDB_"+instance.Name,
 			false,
@@ -187,7 +187,7 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 	dbCreateHash := instance.Status.Hash[databasev1beta1.DbCreateHash]
-	dbCreateJob := common.NewJob(
+	dbCreateJob := job.NewJob(
 		jobDef,
 		databasev1beta1.DbCreateHash,
 		false,

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible // indirect
 	github.com/openstack-k8s-operators/galera-operator/api v0.0.0-00010101000000-000000000000
-	github.com/openstack-k8s-operators/lib-common v0.0.0-20220630111354-9f8383d4a2ea
 	k8s.io/api v0.24.4
 	k8s.io/apimachinery v0.24.4
 	k8s.io/client-go v0.24.4
@@ -16,7 +14,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 
-require github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220819100430-0319abfd42d9
+require github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221115095652-2c390a9d20b4
 
 require (
 	cloud.google.com/go v0.81.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -400,12 +400,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible h1:6il8W875Oq9vycPkRV5TteLP9IfMEX3lyOl5yN+CtdI=
-github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
-github.com/openstack-k8s-operators/lib-common v0.0.0-20220630111354-9f8383d4a2ea h1:VDUbAuG4E4wxfAF2ElzSvE5XnrLHlsOjx7fXvQh3gzs=
-github.com/openstack-k8s-operators/lib-common v0.0.0-20220630111354-9f8383d4a2ea/go.mod h1:sjH9zj16njdfy4PedlQGbJlwu9EXM2ugHhPA/l0zddM=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220819100430-0319abfd42d9 h1:3g6+RKXFGE0qB5XVhTjhn0NlaAERY/vBX7gMsHxZRJA=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20220819100430-0319abfd42d9/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221115095652-2c390a9d20b4 h1:YOsO2TEyi/raaOTGTa3FjIXcZIxjTmiI9DiLWwN2NZo=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221115095652-2c390a9d20b4/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/database.go
+++ b/pkg/database.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	databasev1beta1 "github.com/openstack-k8s-operators/galera-operator/api/v1beta1"
-	common "github.com/openstack-k8s-operators/lib-common/pkg/common"
+	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +20,7 @@ type dbCreateOptions struct {
 func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string) (*batchv1.Job, error) {
 
 	opts := dbCreateOptions{database.Spec.Name, databaseHostName, "root"}
-	dbCmd, err := common.ExecuteTemplateFile("database.sh", &opts)
+	dbCmd, err := util.ExecuteTemplateFile("database.sh", &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName s
 func DeleteDbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string) (*batchv1.Job, error) {
 
 	opts := dbCreateOptions{database.Spec.Name, databaseHostName, "root"}
-	delCmd, err := common.ExecuteTemplateFile("delete_database.sh", &opts)
+	delCmd, err := util.ExecuteTemplateFile("delete_database.sh", &opts)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/galera/bin/detect_gcomm_and_start.sh
+++ b/templates/galera/bin/detect_gcomm_and_start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+URI_FILE=/var/lib/mysql/gcomm_uri
+
+rm -f /var/lib/mysql/mysql.sock
+rm -f $URI_FILE
+
+echo "Waiting for gcomm URI to be configured for this POD"
+while [ ! -f $URI_FILE ]; do
+      sleep 2
+done
+URI=$(cat $URI_FILE)
+if [ "$URI" = "gcomm://" ]; then
+   echo "this POD will now bootstrap a new galera cluster"
+   sed -i -e 's/^\(safe_to_bootstrap\):.*/\1: 1/' /var/lib/mysql/grastate.dat
+else
+   echo "this POD will now join cluster $URI"
+fi
+
+rm -f $URI_FILE
+exec /usr/libexec/mysqld --wsrep-cluster-address="$URI"

--- a/templates/galera/bin/detect_last_commit.sh
+++ b/templates/galera/bin/detect_last_commit.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Adapted from clusterlab's galera resource agent
+recover_args="--datadir=/var/lib/mysql \
+              --user=mysql \
+              --skip-networking \
+              --wsrep-cluster-address=gcomm://localhost"
+recovery_file_regex='s/.*WSREP\:.*position\s*recovery.*--log_error='\''\([^'\'']*\)'\''.*/\1/p'
+recovered_position_regex='s/.*WSREP\:\s*[R|r]ecovered\s*position.*\:\(.*\)\s*$/\1/p'
+
+# codership/galera#354
+# Some ungraceful shutdowns can leave an empty gvwstate.dat on
+# disk. This will prevent galera to join the cluster if it is
+# configured to attempt PC recovery. Removing that file makes the
+# node fall back to the normal, unoptimized joining process.
+if [ -f /var/lib/mysql/gvwstate.dat ] && \
+   [ ! -s /var/lib/mysql/gvwstate.dat ]; then
+    echo "empty /var/lib/mysql/gvwstate.dat detected, removing it to prevent PC recovery failure at next restart" >&2
+    rm -f /var/lib/mysql/gvwstate.dat
+fi
+
+echo "attempting to detect last commit version by reading grastate.dat" >&2
+last_commit="$(cat /var/lib/mysql/grastate.dat | sed -n 's/^seqno.\s*\(.*\)\s*$/\1/p')"
+if [ -z "$last_commit" ] || [ "$last_commit" = "-1" ]; then
+    tmp=$(mktemp)
+    chown mysql:mysql $tmp
+
+    # if we pass here because grastate.dat doesn't exist,
+    # try not to bootstrap from this node if possible
+    # if [ ! -f /var/lib/mysql/grastate.dat ]; then
+    #     set_no_grastate
+    # fi
+
+    echo "now attempting to detect last commit version using 'mysqld_safe --wsrep-recover'" >&2
+
+    mysqld_safe --wsrep-recover $recover_args --log-error=$tmp 1>&2
+
+    last_commit="$(cat $tmp | sed -n $recovered_position_regex | tail -1)"
+    if [ -z "$last_commit" ]; then
+        # Galera uses InnoDB's 2pc transactions internally. If
+        # server was stopped in the middle of a replication, the
+        # recovery may find a "prepared" XA transaction in the
+        # redo log, and mysql won't recover automatically
+
+        recovery_file="$(cat $tmp | sed -n $recovery_file_regex)"
+        if [ -e $recovery_file ]; then
+            cat $recovery_file | grep -q -E '\[ERROR\]\s+Found\s+[0-9]+\s+prepared\s+transactions!' 2>/dev/null
+            if [ $? -eq 0 ]; then
+                # we can only rollback the transaction, but that's OK
+                # since the DB will get resynchronized anyway
+                echo "local node was not shutdown properly. Rollback stuck transaction with --tc-heuristic-recover" >&2
+                mysqld_safe --wsrep-recover $recover_args \
+                            --tc-heuristic-recover=rollback --log-error=$tmp 2>/dev/null
+
+                last_commit="$(cat $tmp | sed -n $recovered_position_regex | tail -1)"
+                if [ ! -z "$last_commit" ]; then
+                    echo "State recovered. force SST at next restart for full resynchronization" >&2
+                    rm -f /var/lib/mysql/grastate.dat
+                    # try not to bootstrap from this node if possible
+                    # set_no_grastate
+                fi
+            fi
+        fi
+    fi
+    rm -f $tmp
+fi
+
+if [ ! -z "$last_commit" ]; then
+    echo "$last_commit"
+    exit 0
+else
+    echo "Unable to detect last known write sequence number" >&2
+    exit 1
+fi

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set +x
+PODNAME=$(hostname -f | cut -d. -f1,2)
+PODIP=$(grep "${PODNAME}" /etc/hosts | cut -d$'\t' -f1)
+sed -e "s/{ PODNAME }/${PODNAME}/" -e "s/{ PODIP }/${PODIP}/" /var/lib/config-data/galera.cnf.in > /var/lib/pod-config-data/galera.cnf
+if [ -e /var/lib/mysql/mysql ]; then
+    echo -e "Database already bootstrapped"
+    exit 0
+fi
+echo -e "\n[mysqld]\nwsrep_provider=none" >> /etc/my.cnf
+kolla_set_configs
+sudo -u mysql -E kolla_extend_start

--- a/templates/galera/bin/mysql_probe.sh
+++ b/templates/galera/bin/mysql_probe.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This secret is mounted by k8s and always up to date
+read -s -u 3 3< /var/lib/secrets/dbpassword MYSQL_PWD
+export MYSQL_PWD
+
+# Consider the pod has "started" once mysql is reachable
+if [ "$1" = "startup" ]; then
+    mysql -sNe "select(1);"
+    exit $?
+fi
+
+case "$1" in
+    readiness)
+	# If the node is e.g. a donor, it cannot serve traffic
+	mysql -sNe "show status like 'wsrep_local_state_comment';" | grep -w -e Synced;;
+    liveness)
+	# If the node is not in the primary partition, restart it
+	mysql -sNe "show status like 'wsrep_cluster_status';" | grep -w -e Primary;;
+    *)
+	echo "Invalid probe option '$1'"
+	exit 1;;
+esac


### PR DESCRIPTION
updated dependency for v0.0.0-20221115095652-2c390a9d20b4 and corrected some names that moved.

something had gone really wrong in my build and it had the latest version of this package but was failing on the package resolution.  something must have changed go.mod and i didnt notice, so anyway, I had to go and learn what was going on here and in the process, confirmed that i can just update these deps to the latest.  im assuming it's OK that we keep the dependency on the latest version as needed...