### PR TITLE
use the given Galera resource name when checking for existing service

### DIFF
--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -243,7 +243,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Check if the main mysql service already exists, if not create a new one
 	svcfound := &corev1.Service{}
-	nsname := types.NamespacedName{Namespace: req.NamespacedName.Namespace, Name: "openstack"}
+	nsname := types.NamespacedName{Namespace: req.NamespacedName.Namespace, Name: galera.Name}
 	err = r.Get(ctx, nsname, svcfound)
 	if err != nil && errors.IsNotFound(err) {
 		// Define a new headless service


### PR DESCRIPTION
the name "openstack" was hardcoded here when the Service it wants to create is named after the Galera.Name parameter
in the Galera definition file.

I've been intentionally running the controller in a cluster that doesn't have the openstack-k8s services installed (except for local-storage) using all different names, partially so that I can identify all the endpoints of the system.   This was the only one that needed a change (besides some "openstack" hardcoded in some of the yamls).