### PR TITLE
possibly helpful directives for devmode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_BUILDER=golang:1.18
-ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:nonroot
+ARG OPERATOR_BASE_IMAGE=gcr.io/distroless/static:debug-nonroot
 
 # Build the manager binary
 FROM $GOLANG_BUILDER AS builder

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go -metrics-bind-address :8088
+	OPERATOR_TEMPLATES=templates/ go run ./main.go -metrics-bind-address :8088
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
@@ -122,7 +122,7 @@ docker-build: test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	podman push ${IMG}
+	podman push --tls-verify=false ${IMG}
 
 ##@ Deployment
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,10 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        # this forces the image to be pulled when the manager is started.
+        # otherwise the same version will be stuck there, making development
+        # with container-deployed controllers impossible.
+        imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:


### PR DESCRIPTION
These are a few things that I have found useful which I think can potentially be generally useful for development, and this PR I'm just showing a sampling, where maybe one or two might be considered useful to merge or just use locally.  However it's not clear regarding "dev only" options, what the best approach is for keeping the code as committed in "production mode" while still being able to flip on options that are strictly dev-oriented.

1. add the 'debug' token to the distroless container.  this is so you can actually run "oc rsh" in the container (just add "busybox sh" as the command to run).  though once we got the templates set up correctly, I no longer needed to shell into the container, so this is pretty dev-only.

2. add OPERATOR_TEMPLATES env to the Makefile's "run" command. This is necessary for the local run of the controller to work and does not affect the production deployment, so I think this is likely useful to merge.

3. add --tls-verify=false to docker-push target.  I have the internal image registry working here, that option is needed in order to push since it uses a local cert, this also might be a dev-only thing if production push should check certs.

4. set imagePullPolicy=Always in the manager deployment spec; I spent a lot of time figuring this one out, as restarting the deployment and/or the pods would otherwise not get the latest version of the image and for awhile I thought we had to give it a different "v" each time, thankfully this was the problem as it defaults to IfNotPresent.  I dont see why one would set it that way because it becomes impossible for a new image hash under the same name/version to be useful.